### PR TITLE
Restrict kms:Decrypt to SSMKMSKeyId

### DIFF
--- a/package-and-deploy.sh
+++ b/package-and-deploy.sh
@@ -9,7 +9,8 @@ DB_PASS_NAME=$6
 VPC=$7
 SUBNET=$8
 SG=$9
-PROFILE=${10}
+KMS_ID=${10}
+PROFILE=${11}
 
 echo "Installing Python dependencies"
 echo "Make sure you have downloaded https://github.com/jkehler/awslambda-psycopg2 into the src folder"
@@ -44,6 +45,7 @@ if [ "${STATUS}" -eq 0 ]; then
             VPCId=${VPC} \
             VPCSubnet=${SUBNET} \
             SecurityGroup=${SG} \
+            SSMKMSKeyId=${KMS_ID} \
         --stack-name psql-script-runner-${DB_NAME} \
         --profile ${PROFILE}
 else

--- a/template.yml
+++ b/template.yml
@@ -53,6 +53,10 @@ Parameters:
     Description: A pre-existing security group which allows access to the RDS database
     Type: AWS::EC2::SecurityGroup::Id
 
+  SSMKMSKeyId:
+    Description: The KMS Key ID for the AWS managed key aws/ssm for the account to be deployed to
+    Type: String
+
 
 ####################################################################################
 Resources:
@@ -118,7 +122,7 @@ Resources:
               - Action:
                 - "kms:Decrypt"
                 Effect: Allow
-                Resource: "*" # TODO: Limit the key by ID
+                Resource: !Sub 'arn:aws:kms::${AWS::AccountId}:key/${SSMKMSKeyId}'
 
   Daily:
     Type: "AWS::Events::Rule"


### PR DESCRIPTION
To address https://rewind.atlassian.net/jira/software/projects/DEVOPS/boards/28?selectedIssue=DEVOPS-271

Add parameter to be passed called SSMKMSKeyId which needs to be the KMS Key ID for the AWS managed key aws/ssm

Updated documentation in https://rewind.atlassian.net/wiki/spaces/DEVOPS/pages/1906966882/Scheduled+PSQL+script+runner to add the appropriate KMS Key ID to be used in the deployment commands